### PR TITLE
ci(mergify): prevent mergify from merging dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,15 +1,4 @@
 pull_request_rules:
-  - name: automatic merge dependabot PRs into dev
-    conditions:
-      - author~=^dependabot(|-preview)\[bot\]$
-      - status-success=Finish Test
-      - base=dev
-      - -title~=\@angular\/
-    actions:
-      merge:
-        method: squash
-        strict: smart+fasttrack
-        strict_method: merge
   - name: merge PRs labeled ready-to-merge
     conditions:
       - status-success=Finish Test


### PR DESCRIPTION
it resulted in constantly broken package-lock files