### PR TITLE
feat(client-ng): expose theme as getter from service

### DIFF
--- a/packages/client-ng/package-lock.json
+++ b/packages/client-ng/package-lock.json
@@ -1683,11 +1683,6 @@
 				}
 			}
 		},
-		"@manniwatch/api-types": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@manniwatch/api-types/-/api-types-0.14.1.tgz",
-			"integrity": "sha512-JuSLsvi6Sd+uB8zjzQ/tOEH89DTvWJaRZDBOAmXNVaRVa9wkxznLFesxp7Rmra6ti56GhjW+mtJ33Ix9D96img=="
-		},
 		"@mapbox/jsonlint-lines-primitives": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",

--- a/packages/client-ng/src/app/routes/settings/theme-selector/theme-selector.component.spec.ts
+++ b/packages/client-ng/src/app/routes/settings/theme-selector/theme-selector.component.spec.ts
@@ -60,7 +60,9 @@ describe('src/routes/settings/theme-selector/theme-selector.component.ts', (): v
                     {
                         provide: SettingsService,
                         useValue: {
-                            setTheme: setThemeSpy,
+                            set theme(th: Theme) {
+                                setThemeSpy(th);
+                            },
                             get themeObservable(): any {
                                 return themeObservableSubscribeSpy();
                             },

--- a/packages/client-ng/src/app/routes/settings/theme-selector/theme-selector.component.ts
+++ b/packages/client-ng/src/app/routes/settings/theme-selector/theme-selector.component.ts
@@ -20,12 +20,12 @@ export class ThemeSelectorComponent implements OnInit, OnDestroy {
 
     }
     public selectTheme(theme: Theme): void {
-        this.settingsService.setTheme(theme);
+        this.settingsService.theme = theme;
     }
 
     public onSelectionChange(change: MatSelectionListChange): void {
         const value: Theme = change.option.value;
-        this.settingsService.setTheme(value);
+        this.settingsService.theme = value;
     }
 
     public ngOnInit(): void {

--- a/packages/client-ng/src/app/services/settings.service.ts
+++ b/packages/client-ng/src/app/services/settings.service.ts
@@ -65,7 +65,18 @@ export class SettingsService {
                 break;
         }
     }
-    public setTheme(theme: Theme): void {
+
+    /**
+     * Returns the current theme
+     */
+    public get theme(): Theme {
+        return this.themeSubject.value;
+    }
+
+    /**
+     * Sets the current theme
+     */
+    public set theme(theme: Theme) {
         this.themeSubject.next(theme);
         this.setThemePreference(theme);
         this.setBodyTheme(theme);


### PR DESCRIPTION
previously there was no way to retrieve the current theme

fix #816