### PR TITLE
ci(github): temporarly remove windows as ci test target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         node: [10, 12]
-        os: [ubuntu-latest, windows-latest]
+        #os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
tests are non stop breaking for no apparent reason on windows

seems to be a known issue noone is able to fix