### PR TITLE
ci(github): change used cache key signature for npm dependencies

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -21,9 +21,9 @@ jobs:
         uses: actions/cache@v2.1.3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-npm-
 
       - name: Install
         run: |
@@ -65,9 +65,9 @@ jobs:
         uses: actions/cache@v2.1.3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-npm-
 
       - name: Install and Build 🔧
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
             ${{ steps.npm-cache.outputs.dir }}
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node
+            ${{ runner.os }}-npm
       - name: Install Deps
         run: |
           npm ci


### PR DESCRIPTION
previous key caused broken test runs

no manual way to delete caches in actions as of now...