### PR TITLE
chore(client-ng): set use-legacy-peer to true

### DIFF
--- a/packages/client-ng/.gitignore
+++ b/packages/client-ng/.gitignore
@@ -48,3 +48,5 @@ Thumbs.db
 # Pug Files
 /src/**/*.html
 /src/*.html
+
+!.npmrc

--- a/packages/client-ng/.npmrc
+++ b/packages/client-ng/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
it would break due to https://github.com/renovatebot/renovate/issues/7474