### PR TITLE
ci(github): use node 12 as minimum version for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       max-parallel: 4
       matrix:
         package: ${{ fromJson(needs.collect-packages.outputs.packages) }}
-        node: [10, 14]
+        node: [12, 14]
         os: [ubuntu-latest] #, windows-latest]
     steps:
       - name: Checkout


### PR DESCRIPTION
as of angular@12 a minimum of node 12 is required