### PR TITLE
fix(api-proxy-router): don't reserialize settings on cache hit

### DIFF
--- a/packages/api-proxy-router/src/endpoints/settings.spec.ts
+++ b/packages/api-proxy-router/src/endpoints/settings.spec.ts
@@ -2,45 +2,36 @@
  * Source https://github.com/manniwatch/manniwatch Package: api-proxy-router
  */
 
-import * as prom from '@donmahallem/turbo';
 import { ManniWatchApiClient } from '@manniwatch/api-client';
 import { expect } from 'chai';
 import express from 'express';
 import 'mocha';
 import NodeCache from 'node-cache';
-import proxyquire from 'proxyquire';
 import sinon, { SinonFakeTimers } from 'sinon';
 import supertest from 'supertest';
 import { SUCCESS_RESPONSE, SUCCESS_RESPONSE_LENGTH } from './common-test.spec';
+import { createSettingsRouter } from './settings';
 
 describe('endpoints/settings.ts', (): void => {
     describe('createSettingsRouter', (): void => {
         let app: express.Express;
-        let promiseStub: sinon.SinonStub;
         let getSettingsStub: sinon.SinonStub;
         let apiClientStub: sinon.SinonStubbedInstance<ManniWatchApiClient>;
         let fakeCache: sinon.SinonStubbedInstance<NodeCache>;
-        let createSettingsRouter: any;
         let sandbox: sinon.SinonSandbox;
         let fakeTimer: SinonFakeTimers;
         before((): void => {
             sandbox = sinon.createSandbox();
-            promiseStub = sandbox.stub(prom, 'promiseToResponse');
             getSettingsStub = sandbox.stub();
             apiClientStub = sandbox.createStubInstance(ManniWatchApiClient, {
                 getSettings: getSettingsStub as any,
             });
-            createSettingsRouter = proxyquire('./settings', {
-                '@donmahallem/turbo': {
-                    promiseToResponse: promiseStub,
-                },
-            }).createSettingsRouter;
             fakeCache = sandbox.createStubInstance(NodeCache);
             fakeTimer = sandbox.useFakeTimers(30000);
         });
 
         beforeEach((): void => {
-            const route: express.Router = createSettingsRouter(apiClientStub as any, fakeCache);
+            const route: express.Router = createSettingsRouter(apiClientStub as any, fakeCache as any);
             app = express();
             app.use('/settings', route);
         });
@@ -52,14 +43,8 @@ describe('endpoints/settings.ts', (): void => {
             fakeTimer.restore();
         });
         describe('query \'\'', (): void => {
-            it('should pass on the provided parameters', async (): Promise<void> => {
+            it('should proxy the request and cache the response', async (): Promise<void> => {
                 getSettingsStub.resolves(SUCCESS_RESPONSE);
-                promiseStub.callsFake((source: Promise<any>, res: express.Response, next: express.NextFunction): void => {
-                    source
-                        .then((responseObject: any): void => {
-                            res.json(responseObject);
-                        });
-                });
                 fakeCache.get.returns(undefined);
                 await supertest(app)
                     .get('/settings')
@@ -71,18 +56,11 @@ describe('endpoints/settings.ts', (): void => {
                     .then((res: supertest.Response): void => {
                         expect(apiClientStub.getSettings.callCount)
                             .to.equal(1, 'getSettings should only be called once');
-                        expect(promiseStub.callCount).to.equal(1);
                         expect(fakeCache.get.callCount).to.equal(1, 'cache should be queried once');
                         expect(fakeCache.set.callCount).to.equal(1, 'cache should be updated once');
                     });
             });
             it('should return value from cache', async (): Promise<void> => {
-                promiseStub.callsFake((source: Promise<any>, res: express.Response, next: express.NextFunction): void => {
-                    source
-                        .then((responseObject: any): void => {
-                            res.json(responseObject);
-                        });
-                });
                 const testLastModified: Date = new Date(10000);
                 fakeCache.get.returns({
                     data: SUCCESS_RESPONSE,
@@ -99,7 +77,6 @@ describe('endpoints/settings.ts', (): void => {
                     .then((res: supertest.Response): void => {
                         expect(apiClientStub.getSettings.callCount)
                             .to.equal(0, 'getSettings should not be called');
-                        expect(promiseStub.callCount).to.equal(1);
                         expect(fakeCache.get.callCount).to.equal(1, 'cache should be queried once');
                         expect(fakeCache.set.callCount).to.equal(0, 'cache should not be updated');
                     });

--- a/packages/api-proxy-router/src/endpoints/settings.ts
+++ b/packages/api-proxy-router/src/endpoints/settings.ts
@@ -2,7 +2,6 @@
  * Source https://github.com/manniwatch/manniwatch Package: api-proxy-router
  */
 
-import * as prom from '@donmahallem/turbo';
 import { ManniWatchApiClient } from '@manniwatch/api-client';
 import { ISettings } from '@manniwatch/api-types';
 import { Mutex } from 'async-mutex';
@@ -11,7 +10,7 @@ import express from 'express';
 import NodeCache from 'node-cache';
 
 interface ISettingsEntry {
-    data: ISettings;
+    data: string;
     etag: string;
     lastModified: Date;
 }
@@ -28,28 +27,29 @@ export const createSettingsRouter: (apiClient: ManniWatchApiClient, cache: NodeC
          * @apiVersion 0.1.0
          */
         router.get('', (req: express.Request, res: express.Response, next: express.NextFunction): void => {
-            const getSettings: Promise<ISettings> = settingsMutex.runExclusive(async (): Promise<ISettingsEntry> => {
+            settingsMutex.runExclusive(async (): Promise<ISettingsEntry> => {
                 const cacheContent: ISettingsEntry | undefined = cache.get(CACHE_KEY_SETTINGS);
                 if (cacheContent) {
                     return cacheContent;
                 }
                 const retrievedSettings: ISettings = await apiClient.getSettings();
+                const serializedData: string = JSON.stringify(retrievedSettings);
                 const hashedData: string = createHash('md5')
-                    .update(JSON.stringify(retrievedSettings), 'utf-8')
+                    .update(serializedData, 'utf-8')
                     .digest('hex');
                 const cacheEntry: ISettingsEntry = {
-                    data: retrievedSettings,
+                    data: serializedData,
                     etag: hashedData,
                     lastModified: new Date(),
                 };
                 cache.set(CACHE_KEY_SETTINGS, cacheEntry, 600);
                 return cacheEntry;
-            }).then((data: ISettingsEntry): ISettings => {
-                res.setHeader('ETag', `W/\"${data.etag}\"`);
-                res.setHeader('Last-Modified', data.lastModified.toUTCString());
-                return data.data;
-            });
-            prom.promiseToResponse(getSettings, res, next);
+            }).then((data: ISettingsEntry): void => {
+                res.set('ETag', `W/\"${data.etag}\"`)
+                    .set('Last-Modified', data.lastModified.toUTCString())
+                    .contentType('application/json; charset=utf-8')
+                    .send(data.data);
+            }).catch(next);
         });
         return router;
     };


### PR DESCRIPTION
fix(api-proxy-router): don't serialize settings on every request on cache hit